### PR TITLE
Fix active line highlight color

### DIFF
--- a/styles/default.less
+++ b/styles/default.less
@@ -184,7 +184,7 @@
   /* Active Line Highlight support */
   .CodeMirror-activeline {
     .CodeMirror-activeline-background, .CodeMirror-activeline-gutter {
-      background-color: #434C5ECC;
+      background-color: #434C5ECC !important;
     }
     .CodeMirror-linenumber {
       color: @nord4;

--- a/styles/default.less
+++ b/styles/default.less
@@ -182,14 +182,19 @@
   }
 
   /* Active Line Highlight support */
-  .CodeMirror-activeline-background {
-    background-color: @nord6;
-  }
-  .CodeMirror-activeline .CodeMirror-linenumber {
-    background-color: @nord6;
-  }
-  .CodeMirror-focused .CodeMirror-activeline .CodeMirror-gutter-elt {
-    background-color: @nord6;
+  .CodeMirror-activeline {
+    .CodeMirror-activeline-background, .CodeMirror-activeline-gutter {
+      background-color: #434C5ECC;
+    }
+    .CodeMirror-linenumber {
+      color: @nord4;
+    }
+    .CodeMirror-foldgutter-open:after {
+      color: @nord4;
+    }
+    .CodeMirror-foldgutter-folded:after {
+      color: @nord4;
+    }
   }
 
   [class*='list-line']


### PR DESCRIPTION
Change highlight color nord6(#ECEFF4) to nord4(#D8DEE9).

Editor:
<img width="936" alt="Screen Shot 2020-03-24 at 20 17 32" src="https://user-images.githubusercontent.com/8362391/77419941-8e0b7580-6e0c-11ea-92d8-5a7aaf983880.png">

Code block:
<img width="935" alt="Screen Shot 2020-03-24 at 20 17 47" src="https://user-images.githubusercontent.com/8362391/77419944-8f3ca280-6e0c-11ea-937d-408dcea6dbcc.png">

